### PR TITLE
Update lambdash-install to remove -e

### DIFF
--- a/lambdash-install
+++ b/lambdash-install
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # lambdash-install - Install lambdash AWS Lambda function with CloudFormation
 #


### PR DESCRIPTION
Had to remove -e to get it to run (EC2 AWS Linux AMI) otherwise it would just exit silently. Am I missing something? I do note that lambdash-uninstall does run as is (with the -e).
