### PR TITLE
update Runtime to nodejs4.3

### DIFF
--- a/lambdash.template
+++ b/lambdash.template
@@ -59,7 +59,7 @@
         "Handler": "index.handler",
         "MemorySize": 1536,
         "Role": {"Fn::GetAtt": ["InvokeRole", "Arn"] },
-        "Runtime": "nodejs",
+        "Runtime": "nodejs4.3",
         "Timeout": 60
       }
     }


### PR DESCRIPTION
According to [Node.js 4.3.2 Runtime Now Available on Lambda](https://aws.amazon.com/blogs/compute/node-js-4-3-2-runtime-now-available-on-lambda/ )

> starting October 2016 you will no longer be able to create functions using Node.js 0.10, given the upcoming end of life for the runtime

"nodejs" still worked as of  4 Jan 2017, but will likely break soon