### PR TITLE
avoid using `new Buffer(...)` to avoid usage of uninitialized memory

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ exports.handler = function(event, context) {
     var child = exec(event.command, {encoding: 'binary', maxBuffer: MAX_OUTPUT},
         function (error, stdout, stderr) {
             var result = {
-                "stdout": new Buffer(stdout, 'binary').toString('base64'),
-                "stderr": new Buffer(stderr, 'binary').toString('base64'),
+                "stdout": Buffer.from(stdout, 'binary').toString('base64'),
+                "stderr": Buffer.from(stderr, 'binary').toString('base64'),
                 "error": error
             };
             context.succeed(result);


### PR DESCRIPTION
see https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md and https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding