### PR TITLE
Upgrade Node runtime to 8.10

### DIFF
--- a/lambdash.template
+++ b/lambdash.template
@@ -59,7 +59,7 @@
         "Handler": "index.handler",
         "MemorySize": 1536,
         "Role": {"Fn::GetAtt": ["InvokeRole", "Arn"] },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs8.10",
         "Timeout": 60
       }
     }


### PR DESCRIPTION
The current version (4.3) is no longer supported by AWS. I manually tested this change. It works on my machine.